### PR TITLE
Simplify the write_file test so that it's not looking up factual info…

### DIFF
--- a/interface/write_file/artifacts_out/random_file.txt
+++ b/interface/write_file/artifacts_out/random_file.txt
@@ -1,1 +1,1 @@
-Washington
+123abc

--- a/interface/write_file/data.json
+++ b/interface/write_file/data.json
@@ -1,13 +1,13 @@
 {
   "name": "TestWriteFile",
   "category": ["interface"],
-  "task": "Print the the capital of America to a .txt file",
+  "task": "Write 123abc to a .txt file",
   "dependencies": [],
   "cutoff": 60,
   "ground": {
-    "answer": "Washington",
-    "should_contain": ["Washington"],
-    "should_not_contain": ["New York", "Los Angeles", "San Francisco"],
+    "answer": "123abc",
+    "should_contain": ["123abc"],
+    "should_not_contain": [],
     "files": [".txt"],
     "eval": {
       "type": "file"


### PR DESCRIPTION
The current version of the write_file test includes factual information that might be looked up instead of simply written. This simplifies the test to ensure it's testing just the file writing functionality.