### PR TITLE
Specify 'all' text in search test

### DIFF
--- a/interface/search/data.json
+++ b/interface/search/data.json
@@ -1,7 +1,7 @@
 {
   "name": "TestSearch",
   "category": ["interface"],
-  "task": "Open 'https://silennaihin.com/random/plain.html' and paste the text on the page in a .txt file",
+  "task": "Open 'https://silennaihin.com/random/plain.html' and paste all of the text on the page in a .txt file",
   "dependencies": ["TestWriteFile"],
   "cutoff": 60,
   "ground": {


### PR DESCRIPTION
The AI sometimes interprets "the text on the page" to mean the content alone. If we are testing for the content _and_ the heading we need to specify that