### PR TITLE
Add poetry run to agent-protocol tests

### DIFF
--- a/interface/agent_protocol_suite/1_create_agent_task/custom_python/test.py
+++ b/interface/agent_protocol_suite/1_create_agent_task/custom_python/test.py
@@ -4,7 +4,7 @@ import sys
 
 def call_agent_protocol() -> None:
     command = (
-        "agent-protocol test --url=http://127.0.0.1:8000 -k test_create_agent_task"
+        "poetry run agent-protocol test --url=http://127.0.0.1:8000 -k test_create_agent_task"
     )
     try:
         result = subprocess.run(command, shell=True, check=True)

--- a/interface/agent_protocol_suite/2_list_agent_tasks_ids/custom_python/test.py
+++ b/interface/agent_protocol_suite/2_list_agent_tasks_ids/custom_python/test.py
@@ -5,7 +5,7 @@ import subprocess
 
 def call_agent_protocol() -> None:
     command = (
-        "agent-protocol test --url=http://127.0.0.1:8000 -k test_list_agent_tasks_ids"
+        "poetry run agent-protocol test --url=http://127.0.0.1:8000 -k test_list_agent_tasks_ids"
     )
     subprocess.run(command, shell=True)
 

--- a/interface/agent_protocol_suite/3_get_agent_task/custom_python/test.py
+++ b/interface/agent_protocol_suite/3_get_agent_task/custom_python/test.py
@@ -4,7 +4,7 @@ import subprocess
 
 
 def call_agent_protocol() -> None:
-    command = "agent-protocol test --url=http://127.0.0.1:8000 -k test_get_agent_task"
+    command = "poetry run agent-protocol test --url=http://127.0.0.1:8000 -k test_get_agent_task"
     subprocess.run(command, shell=True)
 
 

--- a/interface/agent_protocol_suite/4_list_agent_tasks_steps/custom_python/test.py
+++ b/interface/agent_protocol_suite/4_list_agent_tasks_steps/custom_python/test.py
@@ -5,7 +5,7 @@ import subprocess
 
 def call_agent_protocol() -> None:
     command = (
-        "agent-protocol test --url=http://127.0.0.1:8000 -k test_list_agent_task_steps"
+        "poetry run agent-protocol test --url=http://127.0.0.1:8000 -k test_list_agent_task_steps"
     )
     subprocess.run(command, shell=True)
 

--- a/interface/agent_protocol_suite/5_execute_agent_task_step/custom_python/test.py
+++ b/interface/agent_protocol_suite/5_execute_agent_task_step/custom_python/test.py
@@ -4,7 +4,7 @@ import subprocess
 
 
 def call_agent_protocol() -> None:
-    command = "agent-protocol test --url=http://127.0.0.1:8000 -k test_execute_agent_task_step"
+    command = "poetry run agent-protocol test --url=http://127.0.0.1:8000 -k test_execute_agent_task_step"
     subprocess.run(command, shell=True)
 
 


### PR DESCRIPTION
We need `agent-protocol` to be run in the same poetry venv